### PR TITLE
Change compiler to less.php (https://github.com/oyejorge/less.php).

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
     "require": {
         "php": ">=5.2.4",
         "composer/installers": "~1.0",
-        "leafo/lessphp": "0.4.0"
+        "oyejorge/less.php": "~1.7"
     }
 }


### PR DESCRIPTION
One thing to note is that variables within URLs must be place within quotes "" as noted here: https://github.com/sanchothefat/wp-less/issues/67#issuecomment-38369775

This may stop us just switching straight away if projects are reliant on it.